### PR TITLE
Make the group append configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ These variables are defined in [defaults/main.yml](./defaults/main.yml):
 
     users_create_home: true
 
-    shell_use_color: true
+    users_append_groups: false
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,5 @@ users_password_hash: 'sha512'
 users_shell: '/bin/bash/'
 
 users_create_home: true
+
+users_append_groups: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
     password: "{{ item.pass | password_hash(users_password_hash) }}"
     shell: "{{ item.shell | default(users_shell) }}"
     groups: "{{ item.groups | default([]) }}"
-    append: true
+    append: "{{ users_append_groups }}"
     create_home: "{{ item.create_home | default(users_create_home) }}"
     home: "/home/{{ item.name }}/"
     move_home: true
@@ -33,7 +33,7 @@
     name: "{{ item.name }}"
     shell: "{{ item.shell | default(users_shell) }}"
     groups: "{{ item.groups | default([]) }}"
-    append: true
+    append: "{{ users_append_groups }}"
     create_home: "{{ item.create_home | default(users_create_home) }}"
     home: "/home/{{ item.name }}/"
     move_home: true


### PR DESCRIPTION
The default is now false so that only the specified groups will be given to the user.

This attempts to fix #3 so that it is configurable.