### PR TITLE
Remove 'always' task tags

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,6 @@
       assert:
         that:
           - _has_superuser
-      tags: always
 
     - name: establish sudo
       when: _has_superuser

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,6 @@
     that:
       - item.name is defined
       - item.pass is defined or item.ssh_pubkey is defined
-  tags: always
 
 - name: superuser settings
   vars:


### PR DESCRIPTION
Remove the tags: always. It is not good practice to tag tasks in a role. When I run a playbook with specific tags it also runs the task with the always tag.