### PR TITLE
Support to define pass as an encrypted variable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
     _obfuscated_users: "{%- set x=[] -%}
       {%- for user in users_list -%}
       {%-   if 'pass' in user -%}
-      {{-     x.append(user | combine({'pass': (user['pass'] | password_hash(users_password_hash))})) -}}
+      {{-     x.append(user | combine({'pass': (user['pass'] | string | password_hash(users_password_hash))})) -}}
       {%-   else -%}
       {{-     x.append(user) -}}
       {%-   endif -%}


### PR DESCRIPTION
Support to define pass as an encrypted variable. Without this, it failed with this error
```
argument 1 must be str, not AnsibleVaultEncryptedUnicode.
```
It relates to this issue https://github.com/ansible/ansible/issues/47262