### PR TITLE
Remove debian9 CI build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,6 @@ jobs:
           - ubuntu1604
           - centos7
           - centos8
-          - debian9
           - debian10
           - fedora29
     steps:


### PR DESCRIPTION
## What
The build was failing and is no longer necessary.